### PR TITLE
Adding DEFAULT_MESSAGE_HANDLER_KEY to Message Receiver in manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,7 @@
 
                 <category android:name="org.jboss.aerogear.unifiedpush.helloworld"/>
             </intent-filter>
+            <meta-data android:name="DEFAULT_MESSAGE_HANDLER_KEY" android:value="org.jboss.aerogear.unifiedpush.helloworld.handler.NotificationBarMessageHandler"/>
         </receiver>
     </application>
 


### PR DESCRIPTION
Motivation:
DEFAULT_MESSAGE_HANDLER_KEY must be set for notifications to be displayed by the app after a reboot or if the application was force killed.
